### PR TITLE
fix automation.py: if typeID == 9999999999; issue with comparison

### DIFF
--- a/autobloody/automation.py
+++ b/autobloody/automation.py
@@ -56,7 +56,7 @@ class Automation:
             except Exception as e:
                 self._washer()
                 # Quick fix for issue #5 remove it when dropping Neo4j dependency
-                if typeID = 9999999999:
+                if typeID == 9999999999:
                     raise ValueError("The path you're trying to exploit is not exploitable by autobloody only, you may need other tools to exploit it. See #Limitations in the README")
                 raise e
 


### PR DESCRIPTION
Issue:
```bash
❯ python3 ./autobloody.py
Traceback (most recent call last):
  File "/home/pascal/Git/autobloody/./autobloody.py", line 2, in <module>
    from autobloody import main
  File "/home/pascal/Git/autobloody/autobloody/main.py", line 3, in <module>
    from autobloody import automation, database, proxy_bypass
  File "/home/pascal/Git/autobloody/autobloody/automation.py", line 59
    if typeID = 9999999999:
       ^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Maybe you meant '==' or ':=' instead of '='?
```

Need to use `==` for comparison not `=`